### PR TITLE
Exponent ALU Code

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -2,7 +2,7 @@
 This directory includes all documentation surrounding the design choices, for how to run the system please refer to the master README at the root of this project.
 
 ## Block Diagram
-![Floating Point Adder Block Diagram](https://github.com/stweeks-pdx/ECE571IEEE754PointAdder/blob/main/doc/FloatingPointAdder.jpg)
+![Floating Point Adder Block Diagram](doc/FloatingPointAdder.jpg)
 
 ## Floating Point Interface
 For the floating point system the user is required to put their two addends on lines addendA and addendB, when the user wants to begin computation they will set
@@ -15,6 +15,16 @@ period but instead relies on handshaking for the computation.
 
 ## Sub Components
 
+# Exponent ALU
+Exponent ALU
+![Exponent ALU](doc/<something>.jpg)
+
+The Exponent ALU is responsible for detemring which exponent is passed forward and by what amount the system should do a right shift of the smaller exponents'
+mantissa. The exponent ALU takes in two 8-bit wide exponents and returns an 8-bit difference and set bit that are fed to the FSM. First the exponent ALU needs
+to de-bias the incoming exponents by subtracting 128 from them, it then will pass these to a comparison unit that sees if A >= B or A < B. If the former is true
+the ExpSet bit is set to 1, else it is set to 0. This set bit is also used to determine the subtraction operation where the smaller exponent is subtracted from
+the larger and this returns the difference result to ExpDiff.
+
 # Normalizer
 Barrel Shifter
-![Barrel Shifter Circuit](https://github.com/stweeks-pdx/ECE571IEEE754PointAdder/blob/feat/Docs/doc/BarrelShifter.jpg)
+![Barrel Shifter Circuit](doc/BarrelShifter.jpg)

--- a/doc/README.md
+++ b/doc/README.md
@@ -27,4 +27,5 @@ the larger and this returns the difference result to ExpDiff.
 
 # Normalizer
 Barrel Shifter
+
 ![Barrel Shifter Circuit](BarrelShifter.jpg)

--- a/doc/README.md
+++ b/doc/README.md
@@ -2,7 +2,7 @@
 This directory includes all documentation surrounding the design choices, for how to run the system please refer to the master README at the root of this project.
 
 ## Block Diagram
-![Floating Point Adder Block Diagram](./doc/FloatingPointAdder.jpg)
+![Floating Point Adder Block Diagram](FloatingPointAdder.jpg)
 
 ## Floating Point Interface
 For the floating point system the user is required to put their two addends on lines addendA and addendB, when the user wants to begin computation they will set
@@ -27,4 +27,4 @@ the larger and this returns the difference result to ExpDiff.
 
 # Normalizer
 Barrel Shifter
-![Barrel Shifter Circuit](./doc/BarrelShifter.jpg)
+![Barrel Shifter Circuit](BarrelShifter.jpg)

--- a/doc/README.md
+++ b/doc/README.md
@@ -2,7 +2,7 @@
 This directory includes all documentation surrounding the design choices, for how to run the system please refer to the master README at the root of this project.
 
 ## Block Diagram
-![Floating Point Adder Block Diagram](doc/FloatingPointAdder.jpg)
+![Floating Point Adder Block Diagram](./doc/FloatingPointAdder.jpg)
 
 ## Floating Point Interface
 For the floating point system the user is required to put their two addends on lines addendA and addendB, when the user wants to begin computation they will set
@@ -17,7 +17,7 @@ period but instead relies on handshaking for the computation.
 
 # Exponent ALU
 Exponent ALU
-![Exponent ALU](doc/<something>.jpg)
+![Exponent ALU](./doc/<something>.jpg)
 
 The Exponent ALU is responsible for detemring which exponent is passed forward and by what amount the system should do a right shift of the smaller exponents'
 mantissa. The exponent ALU takes in two 8-bit wide exponents and returns an 8-bit difference and set bit that are fed to the FSM. First the exponent ALU needs
@@ -27,4 +27,4 @@ the larger and this returns the difference result to ExpDiff.
 
 # Normalizer
 Barrel Shifter
-![Barrel Shifter Circuit](doc/BarrelShifter.jpg)
+![Barrel Shifter Circuit](./doc/BarrelShifter.jpg)

--- a/src/Makefile
+++ b/src/Makefile
@@ -5,7 +5,7 @@ else
 	EXTRAFLAGS=
 endif
 
-.PHONY: build clean floatpkg barrelshifter
+.PHONY: build clean floatpkg barrelshifter expalu
 build:
 	vlib work
 
@@ -18,4 +18,8 @@ floatpkg:
 
 barrelshifter:
 	vlog -source -lint $(EXTRAFLAGS) barrelshifter.sv barrelshiftertest.sv
+	vsim -c top
+
+expalu:
+	vlog -source -lint $(EXTRAFLAGS) expalu.sv expalutb.sv
 	vsim -c top

--- a/src/expalu.sv
+++ b/src/expalu.sv
@@ -1,6 +1,6 @@
 module ExpALU(ExpA, ExpB, ExpSet, ExpDiff);
 parameter N = 8;
-localparam BIAS = (2**N)/2;
+localparam BIAS = ((2**N)/2) - 1;
 localparam MSB = N - 1;
 
 input [MSB:0] ExpA, ExpB;

--- a/src/expalu.sv
+++ b/src/expalu.sv
@@ -1,0 +1,22 @@
+module ExpALU(ExpA, ExpB, ExpSet, ExpDiff);
+parameter N = 8;
+localparam BIAS = (2**N)/2;
+localparam MSB = N - 1;
+
+input [MSB:0] ExpA, ExpB;
+output [MSB:0] ExpDiff;
+output ExpSet;
+
+logic signed [MSB:0] DeBiasedExpA, DeBiasedExpB;
+
+// Circuit to remove exponent bias
+assign DeBiasedExpA = ExpA - BIAS;
+assign DeBiasedExpB = ExpB - BIAS;
+
+// Comparator Circuit for Exponents
+assign ExpSet = (DeBiasedExpA >= DeBiasedExpB) ? 1 : 0;
+
+// Subtractor Circuit for Exponents
+assign ExpDiff = (ExpSet ? DeBiasedExpA - DeBiasedExpB : DeBiasedExpB - DeBiasedExpA);
+
+endmodule

--- a/src/expalutb.sv
+++ b/src/expalutb.sv
@@ -1,8 +1,8 @@
 module top;
 parameter tN = 8;
-localparam BIAS = (2**tN)/2;
+localparam BIAS = ((2**tN)/2) - 1;
 localparam MIN = (-1*BIAS) + 1;
-localparam MAX = BIAS - 1;
+localparam MAX = BIAS + 1;
 
 // DUT parameters
 logic [tN-1:0] ExpA, ExpB, ExpDiff;

--- a/src/expalutb.sv
+++ b/src/expalutb.sv
@@ -1,0 +1,56 @@
+module top;
+parameter tN = 8;
+localparam BIAS = (2**tN)/2;
+localparam MIN = (-1*BIAS) + 1;
+localparam MAX = BIAS - 1;
+
+// DUT parameters
+logic [tN-1:0] ExpA, ExpB, ExpDiff;
+logic ExpSet;
+
+ExpALU #(tN) DUT(.ExpA, .ExpB, .ExpSet, .ExpDiff);
+
+// Test parameters
+logic [tN-1:0] TDiff;
+logic TSet;
+
+int i, j;
+int Error; // default case is zero
+
+initial
+begin
+`ifdef DEBUG
+	$monitor("ExpA:%d, ExpB:%d, ExpSet:%b, ExpDiff:%d, i:%d, j:%d",
+		   ExpA, ExpB, ExpSet, ExpDiff, i, j);
+`endif
+
+for (i = MIN; i < MAX; i++)
+begin
+	ExpA = i + BIAS;
+	for (j = MIN; j < MAX; j++)
+	begin
+		ExpB = j + BIAS;
+		#100;
+		if (TSet !== ExpSet || TDiff !== ExpDiff)
+		begin
+			$display("****ERROR ExpA = %d, ExpB = %d, Expected: ExpSet = %b, ExpDiff = %d Observed: ExpSet = %b, ExpDiff = %d",
+					ExpA, ExpB, TSet, TDiff, ExpSet, ExpDiff);
+			Error = 1;
+		end 
+	end
+end
+
+if (Error)
+	$display("**** FAILED ****");
+else
+	$display("**** SUCCESS ****");
+end
+
+always_comb
+begin
+	TSet = ExpA >= ExpB;
+	if (i > j) TDiff = i - j;
+	else       TDiff = j - i;
+
+end
+endmodule


### PR DESCRIPTION
This functionality creates the necessary Exponent ALU to decide what amount to shift the mantissa right and which mantissa to select, it also allows us to determine which exponent will flow forward. The biasing unit I think is appropriate here, though we may want to use the biasing component for the MUX flow through as well.

How it works:
The system de-biases the exponent values by subtracting the signed representation of the exponent (2**N/2). It then runs through a comparator and if A >= B sets the bit to 1 else sets it to 0. It then uses this bit to determine subtraction operation and direction and returns the difference (this should always be positive).

Caveat: the de-biased bit needs to be signed to determine the appropriate value when running the subtraction operator. 