### PR TITLE
Control FSM

### DIFF
--- a/src/.gitignore
+++ b/src/.gitignore
@@ -1,0 +1,4 @@
+work/*
+transcript
+floatingpointpkg.sv
+floatingpointpkgtest.sv

--- a/src/assertions.sv
+++ b/src/assertions.sv
@@ -13,31 +13,151 @@ module ControlAssertions #(
 	input logic [$clog2(MANTISSABITS)-1:0] ShiftAmount,
 	input logic SelExpMuxR, SelManMuxR,
 	input StateType State);  //fsm state
-/*
+
 //when reset state = idle
 property p_resetstate;
-	@(posedge Clock)
-	Reset |=> State == IDLE;
+	@(posedge Clock) disable iff (Reset)
+	Reset |=> State === IDLE;
 endproperty
 a_resetstate: assert property(p_resetstate) else $error("on reset state is not IDLE");
 
-//when go =1 nextstate is exp
-property p_exponentstate;
-	@(posedge Clock)
-	Go |=> State == DISSR;
+property p_stransitiondissr;
+	@(posedge Clock) disable iff (Reset)
+	(State === DISSR) |=> (State !== ENSRGT)or(State !== ENSRLT);
 endproperty
-a_exponentstate: assert property(p_exponentstate) else $error("on reset state is not IDLE");
+a_stransitiondissr: assert property(p_stransitiondissr) else $error("State transitions from DISSR to ENSRGT or ENSRLT");
 
-*/	
-	
+property p_stransitionensrgt;
+	@(posedge Clock) disable iff (Reset)
+	(State === ENSRGT) |=> (State !== DISSR)or(State !== ENSRLT);
+endproperty
+a_stransitionensrgt: assert property(p_stransitionensrgt) else $error("State transitions from ENSRGT to DISSR or ENSRLT");
+
+property p_stransitionensrlt;
+	@(posedge Clock) disable iff (Reset)
+	(State === ENSRLT) |=> (State !== DISSR)or(State !== ENSRGT);
+endproperty
+a_stransitionensrlt: assert property(p_stransitionensrlt) else $error("State transitions from ENSRLT to DISSR or ENSRGT");
+
+property p_stransitionsr;
+	@(posedge Clock) disable iff (Reset)
+	(State === SR) |=> (State !== SL)or(State !== NOSHIFT);
+endproperty
+a_stransitionsr: assert property(p_stransitionsr) else $error("State transitions from SR to SL or NOSHIFT");
+
+property p_stransitionsl;
+	@(posedge Clock) disable iff (Reset)
+	(State === SL) |=> (State !== SR)or(State !== NOSHIFT);
+endproperty
+a_stransitionsl: assert property(p_stransitionsl) else $error("State transitions from SL to SR or NOSHIFT");
+
+property p_stransitionnoshift;
+	@(posedge Clock) disable iff (Reset)
+	(State === NOSHIFT) |=> (State !== SL)or(State !== SR);
+endproperty
+a_stransitionnoshift: assert property(p_stransitionnoshift) else $error("State transitions from NOSHIFT to SR or SL");	
+
 //when expmux = rightmux = 1, leftmux = 0 and vice versa
+property p_expgmux;
+	@(posedge Clock) disable iff (Reset)
+	(SelExpMux && SelSRMuxG) |-> (SelSRMuxL == '0);
+endproperty
+a_expgmux: assert property(p_expgmux) else $error("SelSRMuxL is not zero when SelExpMux & SelSRMuxG is set");	
+
+property p_explmux;
+	@(posedge Clock) disable iff (Reset)
+	SelSRMuxL |-> !(SelExpMux && SelSRMuxG);
+endproperty
+a_explmux: assert property(p_explmux) else $error("SelExpMux & SelSRMux is not zero when SelSRMuxL is set");	
+
 //if expdiff is 0 srenable =0 else 1
-//no transition from disSR to engt or enlt and so on
+property p_expdiffz;
+	@(posedge Clock) disable iff (Reset)
+	(ExpDiff == '0) |=> ((ShiftRightEnable == '0) && (ShiftRightAmount == '0));
+endproperty
+a_expdiffz: assert property(p_expdiffz) else $error("SR enable and SR amount is not zero when ExpDiff is zero");	
+
+property p_expdiffnz;
+	@(posedge Clock) disable iff (Reset)
+	(State == IDLE && ExpDiff != '0) |=> (ShiftRightEnable && (ShiftRightAmount == 5'b10111 || ShiftRightAmount == ExpDiff)) ##1 !(ShiftRightEnable && (ShiftRightAmount == 5'b10111 || ShiftRightAmount == ExpDiff));
+endproperty
+a_expdiffnz: assert property(p_expdiffnz) else $error("SR enable and SR amount is not set when ExpDiff is not zero");	
+
+//SelExpMux & SelSRMuxG is set when ExpSet is set and vice versa
+property p_expset;
+	@(posedge Clock) disable iff (Reset)
+	(State == IDLE && ExpSet) |=> (SelExpMux && SelSRMuxG);
+endproperty
+a_expset: assert property(p_expset) else $error("SelExpMux & SelSRMuxG is not set when ExpSet is set");
+
+property p_expsetz;
+	@(posedge Clock) disable iff (Reset)
+	(State == IDLE && !ExpSet) |=> !(SelExpMux && SelSRMuxG);
+endproperty
+a_expsetz: assert property(p_expsetz) else $error("SelExpMux & SelSRMuxG is set when ExpSet is not set");
 
 //if sr = 1,sl= 0 and noshift = 0 and so on
+property p_sren;
+	@(posedge Clock) disable iff (Reset)
+	SREn |-> !SLEn && !NoShift;
+endproperty
+a_sren: assert property(p_sren) else $error("when SREn is set SLEn and NoShift are also set");
+
+property p_slen;
+	@(posedge Clock) disable iff (Reset)
+	SLEn |-> !SREn && !NoShift;
+endproperty
+a_slen: assert property(p_slen) else $error("when SLEn is set SREn and NoShift are also set");
+
+property p_noshift;
+	@(posedge Clock) disable iff (Reset)
+	NoShift |-> !SLEn && !SREn;
+endproperty
+a_noshift: assert property(p_noshift) else $error("when NoShift is set SLEn and SREn are also set");
+
 //if sr =1 incr = 1
+property p_srenincr;
+	@(posedge Clock) disable iff (Reset)
+	SREn |-> IncrEn && !DecrEn && ShiftAmount == 0 ;
+endproperty
+a_srenincr: assert property(p_srenincr) else $error("When SREn is set only IncrEn is set");
+               
 //if sl = 1 decr = 1
-//shift amount = 23 -index
-	
+property p_slendecr;
+	@(posedge Clock) disable iff (Reset)
+	SLEn |-> DecrEn && !IncrEn && ShiftAmount == MANTISSABITS - FFOIndex;
+endproperty
+a_slendecr: assert property(p_slendecr) else $error("When SLEn is set only DecrEn and ShiftAmount are set");
+
+property p_noshiftsincrr;
+	@(posedge Clock) disable iff (Reset)
+	NoShift |-> !IncrEn && !DecrEn && ShiftAmount == 0;
+endproperty
+a_noshiftsincrr: assert property(p_noshiftsincrr) else $error("When NoShift is set IncrEn and DecrEn are not reset");
+
+//FFOValid
+property p_ffovalidshifter;
+	@(posedge Clock) disable iff (Reset)
+	FFOValid && (State == DISSR || State == ENSRGT || State == ENSRLT) |=> SREn || SLEn || NoShift;
+endproperty
+a_ffovalidshifter: assert property(p_ffovalidshifter) else $error("When FFOValid is set either SREn,SLEn or NoShift is not set");
+
+property p_ffovalidreset;
+	@(posedge Clock) disable iff (Reset)
+	!FFOValid && (State == DISSR || State == ENSRGT || State == ENSRLT) |=> NoShift;
+endproperty
+a_ffovalidreset: assert property(p_ffovalidreset) else $error("When FFOValid is reset, NoShift is set");
+
+property p_ffovalidmuxsel;
+	@(posedge Clock) disable iff (Reset)
+	(FFOValid || !FFOValid)&& (State == DISSR || State == ENSRGT || State == ENSRLT)  |=> !SelExpMuxR && !SelManMuxR;
+endproperty
+a_ffovalidmuxsel: assert property(p_ffovalidmuxsel) else $error("When FFOValid is reset or set, SelExpMuxR and SelManMuxR are set");
+
+property p_normuxsel;
+	@(posedge Clock) disable iff (Reset)
+	!SelExpMuxR && !SelManMuxR && Out[24] |=> (SelExpMuxR && SelManMuxR)[*1:$] ##1 !Out[24];
+endproperty
+a_normuxsel: assert property(p_normuxsel) else $error("SelExpMuxR and SelManMuxR are not set during rounding"); 
 	
 endmodule

--- a/src/assertions.sv
+++ b/src/assertions.sv
@@ -1,0 +1,43 @@
+import controlpkg::*;
+module ControlAssertions #(
+	parameter EXPBITS = 8,
+	parameter MANTISSABITS = 23)  
+(	input logic Go,Clock,Reset,ExpSet,
+	input logic [EXPBITS-1:0] ExpDiff,
+	input logic FFOValid,
+	input logic [$clog2(MANTISSABITS)-1:0] FFOIndex,
+	input logic [MANTISSABITS+1:0] Out,
+	input logic SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable,
+	input logic [$clog2(MANTISSABITS)-1:0] ShiftRightAmount,
+	input logic SREn,SLEn,NoShift,IncrEn,DecrEn,
+	input logic [$clog2(MANTISSABITS)-1:0] ShiftAmount,
+	input logic SelExpMuxR, SelManMuxR,
+	input StateType State);  //fsm state
+/*
+//when reset state = idle
+property p_resetstate;
+	@(posedge Clock)
+	Reset |=> State == IDLE;
+endproperty
+a_resetstate: assert property(p_resetstate) else $error("on reset state is not IDLE");
+
+//when go =1 nextstate is exp
+property p_exponentstate;
+	@(posedge Clock)
+	Go |=> State == DISSR;
+endproperty
+a_exponentstate: assert property(p_exponentstate) else $error("on reset state is not IDLE");
+
+*/	
+	
+//when expmux = rightmux = 1, leftmux = 0 and vice versa
+//if expdiff is 0 srenable =0 else 1
+//no transition from disSR to engt or enlt and so on
+
+//if sr = 1,sl= 0 and noshift = 0 and so on
+//if sr =1 incr = 1
+//if sl = 1 decr = 1
+//shift amount = 23 -index
+	
+	
+endmodule

--- a/src/assertions.sv
+++ b/src/assertions.sv
@@ -11,7 +11,7 @@ module ControlAssertions #(
 	input logic [$clog2(MANTISSABITS*2)-1:0] ShiftRightAmount,
 	input logic SREn,SLEn,NoShift,
 	input logic [$clog2(MANTISSABITS)-1:0] ShiftAmount,
-	input logic SelMuxR,Ready,
+	input logic SelMuxR,FlagResult,
 	input StateType State);  //fsm state
 
 //when reset state = idle
@@ -162,9 +162,9 @@ a_normuxsel: assert property(p_normuxsel) else $error("SelMuxR is not set during
 
 property p_validresult;
 	@(posedge Clock) disable iff (Reset)
-	$fell(Go) ##1 !Go[*1:$] ##1 Ready |-> Ready throughout Go[->1];
+	$fell(Go) |=> !Go[*1:$] ##1 FlagResult ##1 !FlagResult throughout Go[->1];
 	endproperty
-a_validresult: assert property(p_validresult) else $error("Ready is not set high until Go is asserted"); 
+a_validresult: assert property(p_validresult) else $error("FlagResult is not set high after rounding"); 
 
 
 endmodule

--- a/src/control.sv
+++ b/src/control.sv
@@ -55,8 +55,8 @@ module Control #(
 	//enum logic [2:0] {IDLE,DISSR,ENSRGT,ENSRLT,SR,SL,NOSHIFT} State, NextState;
 	StateType State,NextState;
 					
-	localparam INDEXCARRY = 25;
-	localparam INDEXONE = 24;
+	localparam INDEXCARRY = 24;
+	localparam INDEXONE = 23;
 	localparam NBITS = $clog2(MANTISSABITS);
 	logic [NBITS-1:0] MBITSEN = 5'b10111; // MBITSEN = 23;
 	
@@ -91,6 +91,8 @@ module Control #(
 					NextState = NOSHIFT;
 				else if (FFOValid && FFOIndex < INDEXONE)
 					NextState = SL;
+				else if (!FFOValid)
+					NextState = NOSHIFT;
 				else
 					NextState = DISSR;
 			end
@@ -102,6 +104,8 @@ module Control #(
 					NextState = NOSHIFT;
 				else if (FFOValid && FFOIndex < INDEXONE)
 					NextState = SL;
+				else if (!FFOValid)
+					NextState = NOSHIFT;
 				else
 					NextState = ENSRGT;
 			end
@@ -113,39 +117,41 @@ module Control #(
 					NextState = NOSHIFT;
 				else if (FFOValid && FFOIndex < INDEXONE)
 					NextState = SL;
+				else if (!FFOValid)
+					NextState = NOSHIFT;
 				else
 					NextState = ENSRLT;
 				end
 				
 		SR: begin
-				if (Out[INDEXONE]=='0)
+				if (Out[INDEXCARRY]=='0)
 						NextState = IDLE;
-					else if (Out[INDEXONE])
+					else if (Out[INDEXCARRY])
 						NextState = ROUND;
 					else
 						NextState = SR;
 				end
 				
 		SL: begin
-				if (Out[INDEXONE]=='0)
+				if (Out[INDEXCARRY]=='0)
 						NextState = IDLE;
-					else if (Out[INDEXONE])
+					else if (Out[INDEXCARRY])
 						NextState = ROUND;
 					else
 						NextState = SL;			
 				end
 				
 		NOSHIFT: begin
-					if (Out[INDEXONE]=='0)
+					if (Out[INDEXCARRY]=='0)
 						NextState = IDLE;
-					else if (Out[INDEXONE])
+					else if (Out[INDEXCARRY])
 						NextState = ROUND;
 					else
 						NextState = NOSHIFT;		
 				end
 				
 		ROUND: begin
-					if (Out[INDEXONE]=='0)
+					if (Out[INDEXCARRY]=='0)
 						NextState = IDLE;
 					else
 						NextState = ROUND;

--- a/src/control.sv
+++ b/src/control.sv
@@ -1,0 +1,208 @@
+package controlpkg;
+typedef enum logic [2:0] {IDLE,DISSR,ENSRGT,ENSRLT,SR,SL,NOSHIFT,ROUND} StateType;
+endpackage
+
+/**************************
+//inputs for the right shifter
+	SelExpMux -- selector for the exponent mux
+	SelSRMuxL -- selector for right shifter mux 1 (LHS in the pdf)
+	SelSRMuxG -- selector for right shifter mux 2 (RHS in the pdf)
+	ShiftRightEnable -- enables the right shifter
+	ShiftRightAmount -- Amount of bits to be shifted
+//inputs to normalizing circuit
+	SREn - enables right shifter
+	SLEn - enables left shifter
+	ShiftAmount - Amount of bits to be shifted in case of left shifter
+	NoShift - disable left and right shifter
+	IncrEn - increment the exponent
+	DecrEn - decrement the exponent
+	SelExpMuxR - selector for the exponent mux in case of rounding(rounding the 2nd time) 
+	SelManMuxR - selector for the mantissa mux in case of rounding(rounding the 2nd time)
+**************************/
+
+
+module Control #(
+	parameter EXPBITS = 8,
+	parameter MANTISSABITS = 23)  
+(
+	input Go,Clock,Reset,
+	//inputs from exponent difference
+	input ExpSet,
+	input [EXPBITS-1:0] ExpDiff,
+	//inputs from FFO
+	input FFOValid,
+	input [$clog2(MANTISSABITS)-1:0] FFOIndex,
+	// inputs from rounding hardware
+	input [MANTISSABITS+1:0] Out,
+	//inputs to shift right
+	output logic SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable,
+	output logic [$clog2(MANTISSABITS)-1:0] ShiftRightAmount,
+	//inputs to normalize 
+	output logic SREn,SLEn,NoShift,IncrEn,DecrEn,
+	output logic [$clog2(MANTISSABITS)-1:0] ShiftAmount,
+	output logic SelExpMuxR, SelManMuxR );
+
+	import controlpkg::*;
+
+	//enum {I_POS= 0,D_POS = 1,EGT_POS = 2,ELT_POS = 3,SR_POS = 4, SL_POS = 5, NS_POS = 6}StateBit;
+	/*enum logic [6:0] {IDLE = 7'b0000001<<I_POS,
+					DISSR  = 7'b0000001<<D_POS,
+					ENSRGT = 7'b0000001<<EGT_POS,
+					ENSRLT = 7'b0000001<<ELT_POS,
+					SR 	   = 7'b0000001<<SR_POS,
+					SL     = 7'b0000001<<SL_POS,
+					NOSHIFT= 7'b0000001<<NS_POS} State, NextState;*/
+	//enum logic [2:0] {IDLE,DISSR,ENSRGT,ENSRLT,SR,SL,NOSHIFT} State, NextState;
+	StateType State,NextState;
+					
+	localparam INDEXCARRY = 25;
+	localparam INDEXONE = 24;
+	localparam NBITS = $clog2(MANTISSABITS);
+	logic [NBITS-1:0] MBITSEN = 5'b10111; // MBITSEN = 23;
+	
+	always_ff @ (posedge Clock)
+	begin
+		if (Reset)
+			State <= IDLE;
+		else
+			State <= NextState;
+	end
+	
+	//Next State Logic
+	always_comb
+	begin
+		NextState = State;
+		unique case (State)		
+		IDLE: begin
+				if (ExpDiff == '0 && Go)
+					NextState = DISSR;
+				else if (ExpSet == '1 && ExpDiff != '0 && Go)
+					NextState = ENSRGT;
+				else if (ExpSet == '0 && Go)
+					NextState = ENSRLT;
+				else
+					NextState = IDLE;
+			end
+				
+		DISSR: begin
+				if (FFOValid && FFOIndex == INDEXCARRY)
+					NextState = SR;
+				else if (FFOValid && FFOIndex == INDEXONE)
+					NextState = NOSHIFT;
+				else if (FFOValid && FFOIndex < INDEXONE)
+					NextState = SL;
+				else
+					NextState = DISSR;
+			end
+				
+		ENSRGT: begin
+				if (FFOValid && FFOIndex == INDEXCARRY)
+					NextState = SR;
+				else if (FFOValid && FFOIndex == INDEXONE)
+					NextState = NOSHIFT;
+				else if (FFOValid && FFOIndex < INDEXONE)
+					NextState = SL;
+				else
+					NextState = ENSRGT;
+			end
+				
+		ENSRLT: begin
+				if (FFOValid && FFOIndex == INDEXCARRY)
+					NextState = SR;
+				else if (FFOValid && FFOIndex == INDEXONE)
+					NextState = NOSHIFT;
+				else if (FFOValid && FFOIndex < INDEXONE)
+					NextState = SL;
+				else
+					NextState = ENSRLT;
+				end
+				
+		SR: begin
+				if (Out[INDEXONE]=='0)
+						NextState = IDLE;
+					else if (Out[INDEXONE])
+						NextState = ROUND;
+					else
+						NextState = SR;
+				end
+				
+		SL: begin
+				if (Out[INDEXONE]=='0)
+						NextState = IDLE;
+					else if (Out[INDEXONE])
+						NextState = ROUND;
+					else
+						NextState = SL;			
+				end
+				
+		NOSHIFT: begin
+					if (Out[INDEXONE]=='0)
+						NextState = IDLE;
+					else if (Out[INDEXONE])
+						NextState = ROUND;
+					else
+						NextState = NOSHIFT;		
+				end
+				
+		ROUND: begin
+					if (Out[INDEXONE]=='0)
+						NextState = IDLE;
+					else
+						NextState = ROUND;
+				end
+		endcase
+	end
+	
+	//output logic
+	always_comb
+	begin
+		{SelExpMux,SelSRMuxL,SelSRMuxG} = '0;
+		{ShiftRightEnable,ShiftRightAmount} = '0;
+		{SREn,SLEn,NoShift,ShiftAmount} = '0;
+		{IncrEn,DecrEn} = '0;
+		{SelExpMuxR,SelManMuxR} = '0;
+		
+		unique case (State)
+		IDLE: begin
+				{SelExpMux,SelSRMuxL,SelSRMuxG} = '0;
+				{ShiftRightEnable,ShiftRightAmount} = '0;
+				{SREn,SLEn,NoShift,ShiftAmount} = '0;
+				{IncrEn,DecrEn} = '0;
+				{SelExpMuxR,SelManMuxR} = '0;
+			end
+		
+		DISSR: begin
+				SelExpMux = '1; SelSRMuxG = '1;
+			end
+				
+		ENSRGT: begin
+				ShiftRightEnable = '1; 
+				ShiftRightAmount = ExpDiff > MANTISSABITS ? MBITSEN : ExpDiff;
+				SelExpMux = '1; SelSRMuxG = '1;
+			end
+		
+		ENSRLT: begin
+				ShiftRightEnable = '1; 
+				ShiftRightAmount = ExpDiff > MANTISSABITS ? MBITSEN : ExpDiff;
+				SelSRMuxL = '1;
+			end
+		
+		SR: begin
+			SREn = '1; IncrEn = '1; 
+			end
+		
+		SL: begin
+			SLEn = '1; DecrEn = '1;
+			ShiftAmount = MBITSEN - FFOIndex;
+			end
+		
+		NOSHIFT: NoShift = '1; 
+			
+		ROUND: begin
+				SelExpMuxR = '1; SelManMuxR = '1;
+				SREn = '1; IncrEn = '1; 
+				end
+		endcase
+	end 
+	
+endmodule

--- a/src/control.sv
+++ b/src/control.sv
@@ -40,7 +40,7 @@ module Control #(
 	output logic SREn,SLEn,NoShift,
 	output logic [$clog2(MANTISSABITS)-1:0] ShiftAmount,
 	output logic SelMuxR,
-	output logic Ready);
+	output logic FlagResult);
 
 	import controlpkg::*;
 
@@ -50,19 +50,6 @@ module Control #(
 	localparam INDEXONE = 23;
 	localparam NBITS = $clog2(MANTISSABITS);
 	logic [NBITS-1:0] MBITSEN = 5'b10111; // MBITSEN = 23;
-	logic FlagResult;
-
-	always_ff @ (posedge Clock)
-	begin
-		if (Reset)
-			Ready <= '0;
-		else if (FlagResult)
-			Ready <= '1;
-		else if (Go)
-			Ready <= '0;
-		else
-			Ready <= Ready;
-	end
 	
 	always_ff @ (posedge Clock)
 	begin

--- a/src/controltb.sv
+++ b/src/controltb.sv
@@ -1,0 +1,81 @@
+module top;
+	parameter EXPBITS = 8;
+	parameter MANTISSABITS = 23;
+	localparam NBITS = $clog2(MANTISSABITS);
+	
+	logic Go,Clock,Reset,ExpSet,FFOValid;
+	logic [EXPBITS-1:0] ExpDiff; 
+	logic [NBITS-1:0] FFOIndex;
+	logic RoundUp;
+	logic [MANTISSABITS+1:0] Out;
+	
+	wire SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable;
+	wire [NBITS-1:0] ShiftRightAmount,ShiftAmount;
+	wire SREn,SLEn,NoShift,IncrEn,DecrEn;
+	wire SelExpMuxR,SelManMuxR;
+	
+	localparam DUTYCYCLE = 10;
+	
+	Control #(EXPBITS,MANTISSABITS) DUT (Go,Clock,Reset,ExpSet,ExpDiff,FFOValid,FFOIndex,Out,SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable,ShiftRightAmount,SREn,SLEn,NoShift,IncrEn,DecrEn,ShiftAmount,SelExpMuxR, SelManMuxR);
+	bind Control ControlAssertions #(EXPBITS,MANTISSABITS) DUTA (Go,Clock,Reset,ExpSet,ExpDiff,FFOValid,FFOIndex,Out,SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable,ShiftRightAmount,SREn,SLEn,NoShift,IncrEn,DecrEn,ShiftAmount,SelExpMuxR,SelManMuxR,State);
+	
+	task Initiate(input logic ready,set,input logic [EXPBITS-1:0] diff);
+		@(negedge Clock)
+		Go = ready;
+		#(DUTYCYCLE/3);
+		ExpSet = set;  ExpDiff = diff;
+	endtask
+	
+	task Normalize(input logic ready,valid,input logic [NBITS-1:0] index);
+		@(negedge Clock); 
+		Go = ready;
+		FFOValid = valid;
+		FFOIndex = index;
+	endtask
+	
+	task Rounding(input logic [MANTISSABITS+1:0] out);
+		@(negedge Clock);
+		Out = out;
+	endtask
+
+
+	initial 
+	begin
+		Clock = '1;
+		forever #DUTYCYCLE Clock = ~Clock;
+	end
+	
+	initial 
+	begin
+		Reset = '1;
+		repeat(2) @(negedge Clock);
+		Reset = '0;
+		
+		//a>b, FFO index = 23,round
+		Initiate('1,'1,{EXPBITS/2{2'b01}});
+		Normalize('0,'1,5'b10111);               
+		Rounding({2'b10,{MANTISSABITS{1'b0}}});
+		Rounding({2'b01,{MANTISSABITS{1'b0}}});
+		
+		//a=b, FFO index = 25,noround
+		Initiate('1,'1,{EXPBITS/2{2'b00}});
+		Normalize('0,'1,5'b11001);               
+		Rounding({2'b00,{MANTISSABITS{1'b1}}});
+		
+		//a<b, FFO index = 24,round
+		Initiate('1,'0,{EXPBITS/2{2'b01}});
+		Normalize('0,'1,5'b11000);               
+		Rounding({2'b10,{MANTISSABITS{1'b1}}});
+		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		
+		repeat(2) @(negedge Clock);	
+		
+	$finish;
+	end
+	
+	
+endmodule
+
+
+
+

--- a/src/controltb.sv
+++ b/src/controltb.sv
@@ -56,7 +56,7 @@ module top;
 		Normalize('0,'1,5'b10111);               
 		Rounding({2'b10,{MANTISSABITS{1'b0}}});
 		Rounding({2'b01,{MANTISSABITS{1'b0}}});
-		
+
 		//a=b, FFO index = 24,noround
 		Initiate('1,'1,{EXPBITS/2{2'b00}});
 		Normalize('0,'1,5'b11000);               
@@ -68,6 +68,7 @@ module top;
 		Rounding({2'b10,{MANTISSABITS{1'b1}}});
 		Rounding({2'b01,{MANTISSABITS{1'b1}}});
 		
+		//equal without additional rounding
 		//a=b, FFO index = 23,noround
 		Initiate('1,'1,{EXPBITS/2{2'b00}});
 		Normalize('0,'1,5'b10111);               
@@ -76,8 +77,119 @@ module top;
 		//a=b, FFOValid=0, FFO index = 23,noround 
 		Initiate('1,'1,{EXPBITS/2{2'b00}});
 		Normalize('0,'0,5'b10111);               
+		Rounding({2'b00,{MANTISSABITS{1'b0}}});
+		
+		//a=b, FFO index = 21,noround
+		Initiate('1,'1,{EXPBITS/2{2'b00}});
+		Normalize('0,'1,5'b10101);               
 		Rounding({2'b00,{MANTISSABITS{1'b1}}});
-	
+		
+		//equal with additional rounding
+		//a=b, FFO index = 23,noround
+		Initiate('1,'1,{EXPBITS/2{2'b00}});
+		Normalize('0,'1,5'b10111);               
+		Rounding({2'b10,{MANTISSABITS{1'b1}}});
+		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		
+		//a=b, FFOValid=0, FFO index = 23,noround 
+		Initiate('1,'1,{EXPBITS/2{2'b00}});
+		Normalize('0,'0,5'b10111);               
+		Rounding({2'b10,{MANTISSABITS{1'b1}}});
+		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		
+		//a=b, FFO index = 21,noround
+		Initiate('1,'1,{EXPBITS/2{2'b00}});
+		Normalize('0,'1,5'b10101);               
+		Rounding({2'b10,{MANTISSABITS{1'b1}}});
+		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		
+		//a=b, FFO index = 24,noround
+		Initiate('1,'1,{EXPBITS/2{2'b00}});
+		Normalize('0,'1,5'b11000);  
+		Rounding({2'b10,{MANTISSABITS{1'b1}}});
+		Rounding({2'b00,{MANTISSABITS{1'b1}}});
+		
+		//greater than with additional rounding
+		//a>b, FFO index = 24,round
+		Initiate('1,'1,{EXPBITS/2{2'b01}});
+		Normalize('0,'1,5'b11000);               
+		Rounding({2'b10,{MANTISSABITS{1'b0}}});
+		Rounding({2'b01,{MANTISSABITS{1'b0}}});
+		
+		//a>b, FFO index = 23,round
+		Initiate('1,'1,{EXPBITS/2{2'b01}});
+		Normalize('0,'0,5'b10111);               
+		Rounding({2'b10,{MANTISSABITS{1'b0}}});
+		Rounding({2'b01,{MANTISSABITS{1'b0}}});
+		
+		//a>b, FFO index = 20,round
+		Initiate('1,'1,{EXPBITS/2{2'b01}});
+		Normalize('0,'1,5'b10100);               
+		Rounding({2'b10,{MANTISSABITS{1'b0}}});
+		Rounding({2'b01,{MANTISSABITS{1'b0}}});
+		
+		//greater than without additional rounding
+		//a>b, FFO index = 23,round
+		Initiate('1,'1,{EXPBITS/2{2'b01}});
+		Normalize('0,'1,5'b10111);               
+		Rounding({2'b01,{MANTISSABITS{1'b0}}});
+		
+		//a>b, FFO index = 24,round
+		Initiate('1,'1,{EXPBITS/2{2'b01}});
+		Normalize('0,'1,5'b11000);               
+		Rounding({2'b01,{MANTISSABITS{1'b0}}});
+		
+		//a>b, FFO index = 23,round
+		Initiate('1,'1,{EXPBITS/2{2'b01}});
+		Normalize('0,'0,5'b10111);               
+		Rounding({2'b01,{MANTISSABITS{1'b0}}});
+		
+		//a>b, FFO index = 20,round
+		Initiate('1,'1,{EXPBITS/2{2'b01}});
+		Normalize('0,'1,5'b10100);               
+		Rounding({2'b01,{MANTISSABITS{1'b0}}});
+		
+		//less than with additional rounding
+		//a<b, FFO index = 23,round
+		Initiate('1,'0,{EXPBITS/2{2'b01}});
+		Normalize('0,'1,5'b10111);               
+		Rounding({2'b10,{MANTISSABITS{1'b1}}});
+		Rounding({2'b11,{MANTISSABITS{1'b1}}});
+		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		
+		//a<b, FFO index = 24,round
+		Initiate('1,'0,{EXPBITS/2{2'b01}});
+		Normalize('0,'0,5'b11000);               
+		Rounding({2'b10,{MANTISSABITS{1'b1}}});
+		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		
+		//a<b, FFO index = 24,round
+		Initiate('1,'0,{EXPBITS/2{2'b01}});
+		Normalize('0,'1,5'b11000);               
+		Rounding({2'b10,{MANTISSABITS{1'b1}}});
+		Rounding({2'b11,{MANTISSABITS{1'b1}}});
+		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		
+		//less than with no additional rounding
+		//a<b, FFO index = 23,round
+		Initiate('1,'0,{EXPBITS/2{2'b01}});
+		Normalize('0,'1,5'b10111);               
+		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		
+		//a<b, FFO index = 24,round
+		Initiate('1,'0,{EXPBITS/2{2'b01}});
+		Normalize('0,'0,5'b11000);               
+		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		
+		//a<b, FFO index = 24,round
+		Initiate('1,'0,{EXPBITS/2{2'b01}});
+		Normalize('0,'1,5'b11000);               
+		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		
+		//a<b, FFO index = 22,round
+		Initiate('1,'0,{EXPBITS/2{2'b01}});
+		Normalize('0,'1,5'b10110);               
+		Rounding({2'b01,{MANTISSABITS{1'b1}}});
 		
 		repeat(2) @(negedge Clock);	
 		

--- a/src/controltb.sv
+++ b/src/controltb.sv
@@ -13,7 +13,7 @@ module top;
 	wire [NBITSE-1:0] ShiftRightAmount;
 	wire [NBITS-1:0] ShiftAmount;
 	wire SREn,SLEn,NoShift;
-	wire SelMuxR,Ready;
+	wire SelMuxR,FlagResult;
 	
 	localparam DUTYCYCLE = 10;
 	

--- a/src/controltb.sv
+++ b/src/controltb.sv
@@ -2,40 +2,41 @@ module top;
 	parameter EXPBITS = 8;
 	parameter MANTISSABITS = 23;
 	localparam NBITS = $clog2(MANTISSABITS);
+	localparam NBITSE = $clog2(MANTISSABITS*2);
 	
 	logic Go,Clock,Reset,ExpSet,FFOValid;
-	logic [EXPBITS-1:0] ExpDiff; 
-	logic [NBITS-1:0] FFOIndex;
-	logic RoundUp;
-	logic [MANTISSABITS+1:0] Out;
+	logic [EXPBITS-1:0] ExpDiff,Diff;
+	logic [NBITS-1:0] FFOIndex,Index;
+	logic [MANTISSABITS+1:0] roundedMant;
 	
 	wire SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable;
-	wire [NBITS-1:0] ShiftRightAmount,ShiftAmount;
-	wire SREn,SLEn,NoShift,IncrEn,DecrEn;
-	wire SelExpMuxR,SelManMuxR,Result;
+	wire [NBITSE-1:0] ShiftRightAmount;
+	wire [NBITS-1:0] ShiftAmount;
+	wire SREn,SLEn,NoShift;
+	wire SelMuxR,Ready;
 	
 	localparam DUTYCYCLE = 10;
 	
-	Control #(EXPBITS,MANTISSABITS) DUT (Go,Clock,Reset,ExpSet,ExpDiff,FFOValid,FFOIndex,Out,SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable,ShiftRightAmount,SREn,SLEn,NoShift,IncrEn,DecrEn,ShiftAmount,SelExpMuxR, SelManMuxR,Result);
-	bind Control ControlAssertions #(EXPBITS,MANTISSABITS) DUTA (Go,Clock,Reset,ExpSet,ExpDiff,FFOValid,FFOIndex,Out,SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable,ShiftRightAmount,SREn,SLEn,NoShift,IncrEn,DecrEn,ShiftAmount,SelExpMuxR,SelManMuxR,Result,State);
+	Control #(EXPBITS,MANTISSABITS) DUT (.*);
+	bind Control ControlAssertions #(EXPBITS,MANTISSABITS) DUTA (.*);
 	
 	task Initiate(input logic ready,set,input logic [EXPBITS-1:0] diff);
 		@(negedge Clock)
 		Go = ready;
 		#(DUTYCYCLE/3);
-		ExpSet = set;  ExpDiff = diff;
+		ExpSet = set;  ExpDiff = diff; Diff = diff;
 	endtask
 	
 	task Normalize(input logic ready,valid,input logic [NBITS-1:0] index);
 		@(negedge Clock); 
 		Go = ready;
 		FFOValid = valid;
-		FFOIndex = index;
+		FFOIndex = index; Index = index;
 	endtask
 	
-	task Rounding(input logic [MANTISSABITS+1:0] out);
+	task Rounding(input logic [MANTISSABITS+1:0] roundedmant);
 		@(negedge Clock);
-		Out = out;
+		roundedMant = roundedmant;
 		@(negedge Clock);
 	endtask
 

--- a/src/controltb.sv
+++ b/src/controltb.sv
@@ -12,12 +12,12 @@ module top;
 	wire SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable;
 	wire [NBITS-1:0] ShiftRightAmount,ShiftAmount;
 	wire SREn,SLEn,NoShift,IncrEn,DecrEn;
-	wire SelExpMuxR,SelManMuxR;
+	wire SelExpMuxR,SelManMuxR,Result;
 	
 	localparam DUTYCYCLE = 10;
 	
-	Control #(EXPBITS,MANTISSABITS) DUT (Go,Clock,Reset,ExpSet,ExpDiff,FFOValid,FFOIndex,Out,SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable,ShiftRightAmount,SREn,SLEn,NoShift,IncrEn,DecrEn,ShiftAmount,SelExpMuxR, SelManMuxR);
-	bind Control ControlAssertions #(EXPBITS,MANTISSABITS) DUTA (Go,Clock,Reset,ExpSet,ExpDiff,FFOValid,FFOIndex,Out,SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable,ShiftRightAmount,SREn,SLEn,NoShift,IncrEn,DecrEn,ShiftAmount,SelExpMuxR,SelManMuxR,State);
+	Control #(EXPBITS,MANTISSABITS) DUT (Go,Clock,Reset,ExpSet,ExpDiff,FFOValid,FFOIndex,Out,SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable,ShiftRightAmount,SREn,SLEn,NoShift,IncrEn,DecrEn,ShiftAmount,SelExpMuxR, SelManMuxR,Result);
+	bind Control ControlAssertions #(EXPBITS,MANTISSABITS) DUTA (Go,Clock,Reset,ExpSet,ExpDiff,FFOValid,FFOIndex,Out,SelExpMux,SelSRMuxL,SelSRMuxG,ShiftRightEnable,ShiftRightAmount,SREn,SLEn,NoShift,IncrEn,DecrEn,ShiftAmount,SelExpMuxR,SelManMuxR,Result,State);
 	
 	task Initiate(input logic ready,set,input logic [EXPBITS-1:0] diff);
 		@(negedge Clock)
@@ -36,6 +36,7 @@ module top;
 	task Rounding(input logic [MANTISSABITS+1:0] out);
 		@(negedge Clock);
 		Out = out;
+		@(negedge Clock);
 	endtask
 
 
@@ -56,11 +57,13 @@ module top;
 		Normalize('0,'1,5'b10111);               
 		Rounding({2'b10,{MANTISSABITS{1'b0}}});
 		Rounding({2'b01,{MANTISSABITS{1'b0}}});
+		repeat (4) @ (negedge Clock);
 
 		//a=b, FFO index = 24,noround
 		Initiate('1,'1,{EXPBITS/2{2'b00}});
 		Normalize('0,'1,5'b11000);               
 		Rounding({2'b00,{MANTISSABITS{1'b1}}});
+		repeat (4) @ (negedge Clock);
 		
 		//a<b, FFO index = 22,round
 		Initiate('1,'0,{EXPBITS/2{2'b01}});
@@ -78,6 +81,7 @@ module top;
 		Initiate('1,'1,{EXPBITS/2{2'b00}});
 		Normalize('0,'0,5'b10111);               
 		Rounding({2'b00,{MANTISSABITS{1'b0}}});
+		repeat (3) @ (negedge Clock);
 		
 		//a=b, FFO index = 21,noround
 		Initiate('1,'1,{EXPBITS/2{2'b00}});
@@ -96,6 +100,8 @@ module top;
 		Normalize('0,'0,5'b10111);               
 		Rounding({2'b10,{MANTISSABITS{1'b1}}});
 		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		repeat (3) @ (negedge Clock);
+
 		
 		//a=b, FFO index = 21,noround
 		Initiate('1,'1,{EXPBITS/2{2'b00}});
@@ -156,7 +162,8 @@ module top;
 		Rounding({2'b10,{MANTISSABITS{1'b1}}});
 		Rounding({2'b11,{MANTISSABITS{1'b1}}});
 		Rounding({2'b01,{MANTISSABITS{1'b1}}});
-		
+		repeat (3) @ (negedge Clock);
+	
 		//a<b, FFO index = 24,round
 		Initiate('1,'0,{EXPBITS/2{2'b01}});
 		Normalize('0,'0,5'b11000);               
@@ -180,6 +187,7 @@ module top;
 		Initiate('1,'0,{EXPBITS/2{2'b01}});
 		Normalize('0,'0,5'b11000);               
 		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		repeat (3) @ (negedge Clock);
 		
 		//a<b, FFO index = 24,round
 		Initiate('1,'0,{EXPBITS/2{2'b01}});
@@ -191,6 +199,9 @@ module top;
 		Normalize('0,'1,5'b10110);               
 		Rounding({2'b01,{MANTISSABITS{1'b1}}});
 		
+		//Finish
+		Initiate('0,'0,{EXPBITS/2{2'b00}});
+	
 		repeat(2) @(negedge Clock);	
 		
 	$finish;

--- a/src/controltb.sv
+++ b/src/controltb.sv
@@ -50,23 +50,34 @@ module top;
 		Reset = '1;
 		repeat(2) @(negedge Clock);
 		Reset = '0;
-		
+
 		//a>b, FFO index = 23,round
 		Initiate('1,'1,{EXPBITS/2{2'b01}});
 		Normalize('0,'1,5'b10111);               
 		Rounding({2'b10,{MANTISSABITS{1'b0}}});
 		Rounding({2'b01,{MANTISSABITS{1'b0}}});
 		
-		//a=b, FFO index = 25,noround
+		//a=b, FFO index = 24,noround
 		Initiate('1,'1,{EXPBITS/2{2'b00}});
-		Normalize('0,'1,5'b11001);               
+		Normalize('0,'1,5'b11000);               
 		Rounding({2'b00,{MANTISSABITS{1'b1}}});
 		
-		//a<b, FFO index = 24,round
+		//a<b, FFO index = 22,round
 		Initiate('1,'0,{EXPBITS/2{2'b01}});
-		Normalize('0,'1,5'b11000);               
+		Normalize('0,'1,5'b10110);               
 		Rounding({2'b10,{MANTISSABITS{1'b1}}});
 		Rounding({2'b01,{MANTISSABITS{1'b1}}});
+		
+		//a=b, FFO index = 23,noround
+		Initiate('1,'1,{EXPBITS/2{2'b00}});
+		Normalize('0,'1,5'b10111);               
+		Rounding({2'b00,{MANTISSABITS{1'b1}}});
+		
+		//a=b, FFOValid=0, FFO index = 23,noround 
+		Initiate('1,'1,{EXPBITS/2{2'b00}});
+		Normalize('0,'0,5'b10111);               
+		Rounding({2'b00,{MANTISSABITS{1'b1}}});
+	
 		
 		repeat(2) @(negedge Clock);	
 		

--- a/src/floatingpointpkg.sv
+++ b/src/floatingpointpkg.sv
@@ -1,7 +1,8 @@
 package floatingpointpkg;
     parameter VERSION = "0.1";
     parameter EXPBITS = 8;
-    parameter FRACBITS = 23;	
+    parameter FRACBITS = 23;
+    parameter EXPONENT = 255;	
 
     typedef struct packed {
 	logic sign;
@@ -21,7 +22,7 @@ package floatingpointpkg;
     endfunction
 
     function automatic bit IsZero(input float f);
-	return ((f.exp === '0) && (f.frac === 0));
+	return ((f.exp === '0) && (f.frac === '0));
     endfunction
 
     function automatic bit IsDenorm(input float f);
@@ -29,11 +30,11 @@ package floatingpointpkg;
     endfunction
 
     function automatic bit IsNaN(input float f);
-	return ((f.exp === '1) && (f.frac !== '0));
+	return ((f.exp === EXPONENT) && (f.frac !== '0));
     endfunction
 
     function automatic bit IsInf(input float f);
-	return ((f.exp === '1) && (f.frac === '0));
+	return ((f.exp === EXPONENT) && (f.frac === '0));
     endfunction
 
 

--- a/src/floatingpointpkg.sv
+++ b/src/floatingpointpkg.sv
@@ -1,7 +1,12 @@
 package floatingpointpkg;
     parameter VERSION = "0.1";
+    parameter EXPBITS = 8;
+    parameter FRACBITS = 23;	
 
     typedef struct packed {
+	logic sign;
+	logic [EXPBITS-1:0] exp;
+	logic [FRACBITS-1:0] frac;	
     } float_t;
 
     typedef float_t float;
@@ -16,15 +21,19 @@ package floatingpointpkg;
     endfunction
 
     function automatic bit IsZero(input float f);
+	return ((f.exp === '0) && (f.frac === 0));
     endfunction
 
     function automatic bit IsDenorm(input float f);
+	return ((f.exp === '0) && (f.frac !== '0));
     endfunction
 
     function automatic bit IsNaN(input float f);
+	return ((f.exp === '1) && (f.frac !== '0));
     endfunction
 
     function automatic bit IsInf(input float f);
+	return ((f.exp === '1) && (f.frac === '0));
     endfunction
 
 

--- a/src/floatingpointpkgtest.sv
+++ b/src/floatingpointpkgtest.sv
@@ -1,0 +1,23 @@
+import floatingpointpkg::*;
+module top;
+
+	task automatic test(input float_t float);
+	$display("IsZero = %b, IsDenorm = %b, IsNaN = %b, IsInf = %b",IsZero(float),IsDenorm(float), IsNaN(float), IsInf(float));
+	endtask
+
+	initial
+	begin
+	test('0);
+	//denorm
+	test(32'h00484444);
+	test(32'h807C67E7);
+	#10;
+	//NaN
+	test(32'hFFD5E7E7);
+	test(32'h7FAAD998);
+	//Inf
+	test(32'hFF800000);
+	test(32'h7F800000);
+	$finish;
+	end
+endmodule

--- a/src/floatingpointpkgtest.sv
+++ b/src/floatingpointpkgtest.sv
@@ -1,23 +1,62 @@
 import floatingpointpkg::*;
 module top;
+	int error;
 
-	task automatic test(input float_t float);
-	$display("IsZero = %b, IsDenorm = %b, IsNaN = %b, IsInf = %b",IsZero(float),IsDenorm(float), IsNaN(float), IsInf(float));
+	task automatic TestFunc(input float_t float);	
+		logic Zero,Denorm,Nan,Inf;
+		logic FZero,FDenorm,FNan,FInf;
+
+		{Zero,Denorm,Nan,Inf} = '0;
+		if (float.exp === 0)
+		begin
+			if (float.frac === 0)
+				Zero = '1;
+			else
+				Denorm = '1;
+		end
+		else if (float.exp === '1)
+		begin
+			if (float.frac === 0)
+				Inf = '1;
+			else
+				Nan = '1;
+		end
+
+		FZero = IsZero(float); FDenorm = IsDenorm(float); FNan = IsNaN(float); FInf = IsInf(float);
+
+		if ({Zero,Denorm,Nan,Inf} !== {FZero,FDenorm,FNan,FInf})
+		begin
+			error = 1;
+			$display("Input: %h",float);
+			$display("Expected Output: IsZero = %b, IsDenorm = %b, IsNaN = %b, IsInf = %b",Zero,Denorm,Nan,Inf);
+			$display("Actual Output: IsZero = %b, IsDenorm = %b, IsNaN = %b, IsInf = %b",FZero,FDenorm,FNan,FInf);
+		end
 	endtask
+
 
 	initial
 	begin
-	test('0);
-	//denorm
-	test(32'h00484444);
-	test(32'h807C67E7);
-	#10;
-	//NaN
-	test(32'hFFD5E7E7);
-	test(32'h7FAAD998);
-	//Inf
-	test(32'hFF800000);
-	test(32'h7F800000);
-	$finish;
+		error = 0;
+		//Zero
+		TestFunc('0);
+		TestFunc('1);
+
+		//denorm
+		TestFunc(32'h00484444);
+		TestFunc(32'h807C67E7);
+
+		//NaN
+		TestFunc(32'hFFD5E7E7);
+		TestFunc(32'h7FAAD998);
+
+		//Inf
+		TestFunc(32'hFF800000);
+		TestFunc(32'h7F800000);
+
+		if (error === 1)
+			$display("TESTS FAILED");
+		else
+			$display("TESTS PASSED");
+		$finish;
 	end
 endmodule


### PR DESCRIPTION
Control FSM is used to enable the modules in the data-path based on the current state of the Floating point adder circuit.